### PR TITLE
Stop HTTP.ERROR: WP HTTP API Error: Too Many Requests - Response code: 429.

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -3,13 +3,13 @@
  Plugin Name: Revisionize
  Plugin URI: https://revisionize.pro
  Description: Draft up revisions of live, published content. The live content doesn't change until you publish the revision manually or with the scheduling system.
- Version: 2.3.5
+ Version: 2.3.6
  Author: Jamie Chong
  Author URI: https://revisionize.pro
  Text Domain: revisionize
  */
 
-/*  
+/*
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or

--- a/settings.php
+++ b/settings.php
@@ -342,11 +342,11 @@ function get_available_addons() {
     $addons = !empty($payload['addons']) ? $payload['addons'] : array();
 
     if (remote_addons_valid($addons)) {
-      set_transient('revisionize_available_addons', $addons, 6 * 60 * 60); // cache for 6 hours
+      \set_transient('revisionize_available_addons', $addons, \WEEK_IN_SECONDS * 2);
     } else {
-      // for some reason our addons list is empty. cache this for a shorter time so site perfomance
+      // for some reason our addons list is empty. cache this for a shorter time so site performance
       // isn't impacted by repeated network calls.
-      set_transient('revisionize_available_addons', $addons, 5 * 60); // cache for 5 minutes
+      \set_transient('revisionize_available_addons', [], \DAY_IN_SECONDS * 5);
     }
   }
 

--- a/settings.php
+++ b/settings.php
@@ -336,7 +336,7 @@ function get_available_addons() {
   $addons = get_transient('revisionize_available_addons');
 
   if ($addons === false) {
-    $response = wp_remote_get("https://revisionize.pro/rvz-addons/");
+    $response = wp_remote_get("https://revisionize.pro/rvz-addons/", array('timeout' => 1, 'httpversion' => '1.1'));
     $json = is_array($response) && !empty($response['body']) ? $response['body'] : '';
     $payload = !empty($json) ? json_decode($json, true) : array();
     $addons = !empty($payload['addons']) ? $payload['addons'] : array();


### PR DESCRIPTION
* Set correct or errant response to longer transient cache time.
* Limit response timeout to "pro" site to 1 second.